### PR TITLE
Fix async actions

### DIFF
--- a/src/Skillion/Directory.Build.props
+++ b/src/Skillion/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.0.2</VersionPrefix>
-        <VersionSuffix></VersionSuffix>
+        <VersionPrefix>1.0.3</VersionPrefix>
+        <VersionSuffix>beta-1-2</VersionSuffix>
     </PropertyGroup>
 </Project>

--- a/src/Skillion/Directory.Build.props
+++ b/src/Skillion/Directory.Build.props
@@ -2,6 +2,6 @@
 <Project>
     <PropertyGroup>
         <VersionPrefix>1.0.3</VersionPrefix>
-        <VersionSuffix>beta-1-2</VersionSuffix>
+        <VersionSuffix></VersionSuffix>
     </PropertyGroup>
 </Project>

--- a/src/Skillion/Middleware/SkillionMiddlewareExtensions.cs
+++ b/src/Skillion/Middleware/SkillionMiddlewareExtensions.cs
@@ -24,38 +24,20 @@ namespace Skillion.Middleware
             services.AddScoped<ISkillRequestParser, SkillRequestParser>();
             services.AddScoped<SkillionRouteValueTransformer>();
             services.AddScoped<ISkillRequestValidator, SkillRequestValidator>();
-            services.AddSingleton<IRouteDataService>(MapRoutes(assembly));
+            services.AddSingleton<IRouteDataService>(new RouteDataService(RouteMapper.MapRoutes(GetMethods(assembly))));
         }
-
+        
         public static void UseSkillion(this IApplicationBuilder app)
         {
             app.UseRouting();
             app.UseEndpoints(e => e.MapDynamicControllerRoute<SkillionRouteValueTransformer>("/"));
         }
-
-        private static RouteDataService MapRoutes(Assembly assembly)
+        
+        private static IEnumerable<MethodInfo> GetMethods(Assembly assembly)
         {
-            var methods = assembly.GetTypes().AsParallel()
+            return assembly.GetTypes().AsParallel()
                 .SelectMany(t => t.GetMethods())
-                .Where(m => m.GetCustomAttributes(typeof(SkillionRequestAttribute), false).Any())
-                .ToArray();
-
-            var routeMapDictionary = new Dictionary<string, RouteData>();
-            foreach (var method in methods)
-            {
-                var skillionAttribute = method.GetCustomAttribute<SkillionRequestAttribute>();
-
-                var type = method.ReflectedType?.FullName?.Split(".");
-                if (type == null || type.Length == 0)
-                    continue;
-
-                var controller = type[^1].Replace("Controller", string.Empty);
-                var action = method.Name;
-
-                routeMapDictionary.Add(skillionAttribute.Name, new RouteData(controller, action));
-            }
-
-            return new RouteDataService(routeMapDictionary);
+                .Where(m => m.GetCustomAttributes(typeof(SkillionRequestAttribute), false).Any());    
         }
     }
 }

--- a/src/Skillion/RouteMapper.cs
+++ b/src/Skillion/RouteMapper.cs
@@ -22,8 +22,8 @@ namespace Skillion
                 if (type == null || type.Length == 0)
                     continue;
 
-                var controller = type[^1].Replace("Controller", string.Empty);
-                var action = RemoveAsyncSuffix(method.Name);
+                var controller = RemoveSuffix(type[^1], "Controller");
+                var action = RemoveSuffix(method.Name, "Async");
 
                 routeMapDictionary.Add(skillionAttribute.Name, new RouteData(controller, action));
             }
@@ -31,10 +31,10 @@ namespace Skillion
             return routeMapDictionary;
         }
         
-        private static string RemoveAsyncSuffix(string action)
+        private static string RemoveSuffix(string value, string suffix)
         {
-            var lastLocation = action.LastIndexOf("Async", StringComparison.Ordinal);
-            return lastLocation == -1 ? action : action.Remove(lastLocation);
+            var lastLocation = value.LastIndexOf(suffix, StringComparison.Ordinal);
+            return lastLocation == -1 ? value : value.Remove(lastLocation);
         }
     }
 }

--- a/src/Skillion/RouteMapper.cs
+++ b/src/Skillion/RouteMapper.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Skillion.Attributes;
+using Skillion.Services;
+
+namespace Skillion
+{
+    internal static class RouteMapper
+    {
+        public static IDictionary<string, RouteData> MapRoutes(IEnumerable<MemberInfo> methods)
+        {
+            var routeMapDictionary = new Dictionary<string, RouteData>();
+            foreach (var method in methods)
+            {
+                var skillionAttribute = method.GetCustomAttribute<SkillionRequestAttribute>();
+
+                if (skillionAttribute is null)
+                    continue;
+                
+                var type = method.ReflectedType?.FullName?.Split(".");
+                if (type == null || type.Length == 0)
+                    continue;
+
+                var controller = type[^1].Replace("Controller", string.Empty);
+                var action = RemoveAsyncSuffix(method.Name);
+
+                routeMapDictionary.Add(skillionAttribute.Name, new RouteData(controller, action));
+            }
+
+            return routeMapDictionary;
+        }
+        
+        private static string RemoveAsyncSuffix(string action)
+        {
+            var lastLocation = action.LastIndexOf("Async", StringComparison.Ordinal);
+            return lastLocation == -1 ? action : action.Remove(lastLocation);
+        }
+    }
+}

--- a/src/Skillion/Skillion.csproj
+++ b/src/Skillion/Skillion.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="../../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+        <None Include="../../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
     </ItemGroup>
     
 </Project>

--- a/tests/ManualTest/Controllers/ValuesController.cs
+++ b/tests/ManualTest/Controllers/ValuesController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Alexa.NET;
 using Alexa.NET.Request;
 using Alexa.NET.Request.Type;
@@ -10,24 +11,18 @@ namespace ManualTest.Controllers
 {
     public class ValuesController : SkillionController
     {
-        [FallbackIntentRequest]
-        public SkillionActionResult<SkillResponse> Fallback()
-        {
-            return Hello();
-        }
-
         [IntentRequest("HelloIntent")]
-        public SkillionActionResult<SkillResponse> Hello()
+        public Task<SkillionActionResult<SkillResponse>> HelloAsyncAsync()
         {
             if (!TryCastRequest<IntentRequest>(out var intent))
-                return ResponseBuilder.TellWithCard("Something went wrong", "Error", "Something went wrong");
+                return Task.FromResult<SkillionActionResult<SkillResponse>>(ResponseBuilder.TellWithCard("Something went wrong", "Error", "Something went wrong"));
 
             var numberOfItems = intent.Intent.Slots != null
                 ? ((IntentRequest) RequestContext).Intent.Slots["NumberOfItems"].Value
                 : "0";
 
             var text = $"Here are your {numberOfItems} items";
-            return ResponseBuilder.TellWithCard(text, "Your items", text);
+            return Task.FromResult<SkillionActionResult<SkillResponse>>(ResponseBuilder.TellWithCard(text, "Your items", text));
         }
 
         [IntentRequest("SessionIntent")]
@@ -43,6 +38,13 @@ namespace ManualTest.Controllers
             var intentRequest = RequestContext as IntentRequest;
             intentRequest?.Intent.Slots.Add("fromCity", new Slot {Name = "fromCity", Value = "Toronto"});
             return ResponseBuilder.DialogDelegate(intentRequest?.Intent);
+        }
+
+        [IntentRequest("AskIntent")]
+        public SkillionActionResult<SkillResponse> Ask()
+        {
+            return ResponseBuilder.Ask("Hello",
+                new Reprompt {OutputSpeech = new PlainTextOutputSpeech {Text = "Is it me you're looking for?"}});
         }
 
         [LaunchRequest]

--- a/tests/ManualTest/ManualTest.csproj
+++ b/tests/ManualTest/ManualTest.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>d8b53ee9-a509-4369-8c32-e87d201ef7e2</UserSecretsId>
     <IsPackable>false</IsPackable>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>

--- a/tests/UnitTests/Helpers/TestMemberInfo.cs
+++ b/tests/UnitTests/Helpers/TestMemberInfo.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Reflection;
+using Skillion.Attributes;
+
+namespace SkillionUnitTests.Helpers
+{
+    public class TestMemberInfo : MemberInfo
+    {
+        private readonly SkillionRequestAttribute[] _customAttributes;
+        
+        public TestMemberInfo(Type type, string name, SkillionRequestAttribute[] customAttributes)
+        {
+            ReflectedType = type;
+            Name = name;
+            _customAttributes = customAttributes;
+        }
+        
+        public override object[] GetCustomAttributes(bool inherit)
+        {
+            return GetCustomAttributes();
+        }
+
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+        {
+            return GetCustomAttributes();
+        }
+
+        public override bool IsDefined(Type attributeType, bool inherit)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Type? DeclaringType { get; }
+        
+        public override MemberTypes MemberType { get; }
+        
+        public override string Name { get; }
+        
+        public override Type? ReflectedType { get; }
+
+        private object[] GetCustomAttributes()
+        {
+            if (_customAttributes == null || _customAttributes.Length == 0)
+                return Array.Empty<object>();
+                        
+            return _customAttributes;
+        }
+    }
+}

--- a/tests/UnitTests/RouteMapperTests.cs
+++ b/tests/UnitTests/RouteMapperTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Moq;
+using Skillion;
+using Skillion.Attributes;
+using SkillionUnitTests.Helpers;
+using Xunit;
+
+namespace SkillionUnitTests
+{
+    public class RouteMapperTests
+    {
+        [Fact]
+        public void GivenControllerAction_WhenHasAttribute_ReturnRoutes()
+        {
+            const string intentName = "TestIntent";
+            const string controllerName = "Test";
+            const string methodName = "TestAction";
+            
+            var controllerNamespace = $"RouteMapperTests.Controllers.{controllerName}Controller";
+
+            var type = new Mock<Type>();
+            type.Setup(t => t.FullName).Returns(controllerNamespace);
+            var testMemberInfo = new TestMemberInfo(type.Object, methodName, new SkillionRequestAttribute[] {new IntentRequestAttribute(intentName)});
+
+            var routes = RouteMapper.MapRoutes(new List<MemberInfo> {testMemberInfo});
+            
+            Assert.True(routes.ContainsKey(intentName));
+            Assert.Equal(controllerName, routes[intentName].Controller);
+        }
+        
+        [Fact]
+        public void GivenControllerAction_WhenDoesNotHaveAttribute_ReturnEmptyRoutes()
+        {
+            const string intentName = "TestIntent";
+            const string controllerName = "Test";
+            const string methodName = "TestAction";
+            
+            var controllerNamespace = $"RouteMapperTests.Controllers.{controllerName}Controller";
+
+            var type = new Mock<Type>();
+            type.Setup(t => t.FullName).Returns(controllerNamespace);
+            var testMemberInfo = new TestMemberInfo(type.Object, methodName, null);
+
+            var routes = RouteMapper.MapRoutes(new List<MemberInfo> {testMemberInfo});
+            
+            Assert.Empty(routes);
+        }
+        
+        [Fact]
+        public void GivenControllerAction_WhenHasAttributeAndAsyncSuffix_ReturnRoutes()
+        {
+            const string intentName = "TestIntent";
+            const string controllerName = "Test";
+            const string methodName = "TestActionAsync";
+            const string truncatedMethodName = "TestAction";
+            
+            var controllerNamespace = $"RouteMapperTests.Controllers.{controllerName}Controller";
+
+            var type = new Mock<Type>();
+            type.Setup(t => t.FullName).Returns(controllerNamespace);
+            var testMemberInfo = new TestMemberInfo(type.Object, methodName, new SkillionRequestAttribute[] {new IntentRequestAttribute(intentName)});
+
+            var routes = RouteMapper.MapRoutes(new List<MemberInfo> {testMemberInfo});
+            
+            Assert.True(routes.ContainsKey(intentName));
+            Assert.Equal(controllerName, routes[intentName].Controller);
+            Assert.Equal(truncatedMethodName, routes[intentName].Action);
+        }
+        
+        [Fact]
+        public void GivenControllerAction_WhenHasAttributeAndDoubleAsyncSuffix_ReturnRoutes()
+        {
+            const string intentName = "TestIntent";
+            const string controllerName = "Test";
+            const string methodName = "TestAsyncAsync";
+            const string truncatedMethodName = "TestAsync";
+            
+            var controllerNamespace = $"RouteMapperTests.Controllers.{controllerName}Controller";
+
+            var type = new Mock<Type>();
+            type.Setup(t => t.FullName).Returns(controllerNamespace);
+            var testMemberInfo = new TestMemberInfo(type.Object, methodName, new SkillionRequestAttribute[] {new IntentRequestAttribute(intentName)});
+
+            var routes = RouteMapper.MapRoutes(new List<MemberInfo> {testMemberInfo});
+            
+            Assert.True(routes.ContainsKey(intentName));
+            Assert.Equal(controllerName, routes[intentName].Controller);
+            Assert.Equal(truncatedMethodName, routes[intentName].Action);
+        }
+    }
+}

--- a/tests/UnitTests/RouteMapperTests.cs
+++ b/tests/UnitTests/RouteMapperTests.cs
@@ -89,5 +89,26 @@ namespace SkillionUnitTests
             Assert.Equal(controllerName, routes[intentName].Controller);
             Assert.Equal(truncatedMethodName, routes[intentName].Action);
         }
+        
+        [Fact]
+        public void GivenControllerAction_WhenHasAttributeAndDoubleControllerSuffix_ReturnRoutes()
+        {
+            const string intentName = "TestIntent";
+            const string controllerName = "TestController";
+            const string methodName = "TestAsyncAsync";
+            const string truncatedMethodName = "TestAsync";
+            
+            var controllerNamespace = $"RouteMapperTests.Controllers.{controllerName}Controller";
+
+            var type = new Mock<Type>();
+            type.Setup(t => t.FullName).Returns(controllerNamespace);
+            var testMemberInfo = new TestMemberInfo(type.Object, methodName, new SkillionRequestAttribute[] {new IntentRequestAttribute(intentName)});
+
+            var routes = RouteMapper.MapRoutes(new List<MemberInfo> {testMemberInfo});
+            
+            Assert.True(routes.ContainsKey(intentName));
+            Assert.Equal(controllerName, routes[intentName].Controller);
+            Assert.Equal(truncatedMethodName, routes[intentName].Action);
+        }
     }
 }

--- a/tests/UnitTests/SkillionActionResultTests.cs
+++ b/tests/UnitTests/SkillionActionResultTests.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Net;
 using System.Reflection;
-using System.Windows.Markup;
 using Alexa.NET.Response;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;


### PR DESCRIPTION
Closes #1 

When parsing routes, remove the async (and controller) suffixes.